### PR TITLE
Working with CSV files without headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,8 @@ crashlytics.properties
 crashlytics-build.properties
 fabric.properties
 
+# Eclipse
+.classpath
+.project
+.settings
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@ dist: trusty
 
 language: java
 
+## https://docs.travis-ci.com/user/languages/java
+## http://stackoverflow.com/questions/20707017/how-to-run-junit-tests-with-gradle
+## how to run tests with gradle https://docs.gradle.org/current/userguide/tutorial_gradle_command_line.html
+## gradle check or gradle test
+
+## http://stackoverflow.com/questions/17606874/trigger-a-travis-ci-rebuild-without-pushing-a-commit
+
 jdk:
   - oraclejdk8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
+dist: trusty
+
 language: java
 
-## https://docs.travis-ci.com/user/languages/java
-## http://stackoverflow.com/questions/20707017/how-to-run-junit-tests-with-gradle
-## how to run tests with gradle https://docs.gradle.org/current/userguide/tutorial_gradle_command_line.html
-## gradle check or gradle test
+jdk:
+  - oraclejdk8
 
-## http://stackoverflow.com/questions/17606874/trigger-a-travis-ci-rebuild-without-pushing-a-commit
+install: gradle -q assemble
+
+script: gradle clean check --stacktrace

--- a/src/main/kotlin/krangl/TableIO.kt
+++ b/src/main/kotlin/krangl/TableIO.kt
@@ -47,7 +47,7 @@ fun DataFrame.Companion.fromCSV(inStream: InputStream, format: CSVFormat = CSVFo
 
 
 internal fun DataFrame.Companion.fromCSV(reader: Reader, format: CSVFormat = CSVFormat.DEFAULT): DataFrame {
-    val csvParser = format.withFirstRecordAsHeader().parse(reader)
+    val csvParser = format.parse(reader)
 
     val records = csvParser.records
 
@@ -163,4 +163,4 @@ Additional variables order, conservation status and vore were added from wikiped
 - brainwt. brain weight in kilograms
 - bodywt. body weight in kilograms
  */
-val sleepData = DataFrame.fromCSV(DataFrame::class.java.getResourceAsStream("data/msleep.csv"))
+val sleepData = DataFrame.fromCSV(DataFrame::class.java.getResourceAsStream("data/msleep.csv"), CSVFormat.DEFAULT.withHeader())

--- a/src/test/kotlin/krangl/test/CoreVerbsTest.kt
+++ b/src/test/kotlin/krangl/test/CoreVerbsTest.kt
@@ -6,8 +6,8 @@ import krangl.*
 import org.apache.commons.csv.CSVFormat
 
 
-val irisData = DataFrame.fromCSV(DataFrame::class.java.getResourceAsStream("data/iris.txt"), format = CSVFormat.TDF)
-val flights = DataFrame.fromCSV(DataFrame::class.java.getResourceAsStream("data/nycflights.tsv.gz"), format = CSVFormat.TDF, isCompressed = true)
+val irisData = DataFrame.fromCSV(DataFrame::class.java.getResourceAsStream("data/iris.txt"), format = CSVFormat.TDF.withHeader())
+val flights = DataFrame.fromCSV(DataFrame::class.java.getResourceAsStream("data/nycflights.tsv.gz"), format = CSVFormat.TDF.withHeader(), isCompressed = true)
 
 
 class SelectTest : FlatSpec() { init {


### PR DESCRIPTION
I wanted to make it work with CSV files without a header. I guess Apache Commons CSV cannot auto detect header so caller needs to have a choice to specify if a header is needed. I also added working travis.yml. 