### PR TITLE
Improve Dataframe unfolding with components

### DIFF
--- a/src/main/kotlin/krangl/util/InternalHelpers.kt
+++ b/src/main/kotlin/krangl/util/InternalHelpers.kt
@@ -58,5 +58,5 @@ inline fun <reified T> detectPropertiesByReflection(): List<KCallable<*>> {
         }
     }
 
-    return propsOrGetters.filterNot { it.name.run { equals("toString") || equals("hashCode") || matches("component[1-5]".toRegex()) } }
+    return propsOrGetters.filterNot { it.name.run { equals("toString") || equals("hashCode") || matches("component[1-9][0-9]*".toRegex()) } }
 }


### PR DESCRIPTION
Problem:
* Assume you defined a data class `MyDataclass` with more than 6 components.
* Then use `dataFrameOf(...)(...).unfold<MyDataClass>(...)` method on that data class.
* The exported CSV contains columns `component6`, `component7`, ...

Identified bug:
* The filtering of copmonent-methods includes only `component1` to `component5`.

Proposed solution:
* Filter all legally allowed Kotlin component-methods by extending the regular expression.