### PR TITLE
Add 'hasNulls' lazy property for DataCol. Used for typed wrappers gen…

### DIFF
--- a/src/main/kotlin/krangl/Columns.kt
+++ b/src/main/kotlin/krangl/Columns.kt
@@ -40,6 +40,8 @@ abstract class DataCol(val name: String) {  // tbd why not: Iterable<Any> ??
 
     abstract fun values(): Array<*>
 
+    val hasNulls by lazy { values().any { it == null } }
+
     abstract val length: Int
 
     override fun toString(): String {


### PR DESCRIPTION
Used in [krangl-typed](https://github.com/nikitinas/krangl-typed) project for checking actual column nullability during typed data frame generation