### PR TITLE
Fixed typo on expected value on Json data URL test

### DIFF
--- a/src/test/kotlin/krangl/test/BuilderTests.kt
+++ b/src/test/kotlin/krangl/test/BuilderTests.kt
@@ -204,7 +204,7 @@ class JsonTests {
 
         df.apply {
             nrow shouldBe 3201
-            names.last() shouldBe "IMDB_Votes"
+            names.last() shouldBe "IMDB Votes"
         }
     }
 


### PR DESCRIPTION
Expected value on test was "IMDB_Votes" while the data had "IMDB Votes", updated it so it matches