### PR TITLE
- Added option to show a different number of records in Jupyter

### DIFF
--- a/src/main/kotlin/krangl/KranglConfig.kt
+++ b/src/main/kotlin/krangl/KranglConfig.kt
@@ -1,0 +1,12 @@
+package krangl
+
+/** Krangl default settings. */
+object KranglConfig {
+    /** Default number of rows to display when printing data-frames in a jupyter notebook.*/
+    var JUPYTER_DISPLAY_MAX_ROWS = 10
+
+    /** Default line length when printing data-frames in a jupyter notebook.*/
+    var JUPYTER_DISPLAY_WIDTH = 50
+}
+
+

--- a/src/main/kotlin/krangl/integration/Integration.kt
+++ b/src/main/kotlin/krangl/integration/Integration.kt
@@ -3,6 +3,8 @@ package krangl.integration
 import krangl.DataFrame
 import krangl.DataFrameSchema
 import krangl.GroupedDataFrame
+import krangl.KranglConfig.JUPYTER_DISPLAY_MAX_ROWS
+import krangl.KranglConfig.JUPYTER_DISPLAY_WIDTH
 import krangl.SimpleDataFrame
 import org.jetbrains.kotlinx.jupyter.api.HTML
 import org.jetbrains.kotlinx.jupyter.api.annotations.JupyterLibrary
@@ -13,8 +15,6 @@ import org.jetbrains.kotlinx.jupyter.api.libraries.JupyterIntegration
 // * https://blog.jetbrains.com/kotlin/2021/04/kotlin-kernel-for-jupyter-notebook-v0-9-0/
 //https://github.com/Kotlin/kotlin-jupyter/blob/master/libraries/krangl.json
 
-var DISPLAY_MAX_ROWS = 10
-var DISPLAY_MAX_CHARS = 50
 
 @JupyterLibrary
 internal class Integration : JupyterIntegration() {
@@ -25,7 +25,11 @@ internal class Integration : JupyterIntegration() {
         render<DataFrameSchema> { HTML(it.toHTML()) }
     }
 
-    fun DataFrame.toHTML(title: String="A DataFrame", maxRows: Int = DISPLAY_MAX_ROWS, truncate: Int = DISPLAY_MAX_CHARS): String = with(StringBuilder()) {
+    fun DataFrame.toHTML(
+        title: String = "A DataFrame",
+        maxRows: Int = JUPYTER_DISPLAY_MAX_ROWS,
+        truncate: Int = JUPYTER_DISPLAY_WIDTH
+    ): String = with(StringBuilder()) {
         append("<html><body>")
 
 
@@ -53,7 +57,7 @@ internal class Integration : JupyterIntegration() {
 
         // render footer
         append("<p>")
-        if (maxRows < rows.count()){
+        if (maxRows < rows.count()) {
             append("... with ${nrow - maxRows} more rows. ")
         }
 

--- a/src/main/kotlin/krangl/integration/Integration.kt
+++ b/src/main/kotlin/krangl/integration/Integration.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlinx.jupyter.api.libraries.JupyterIntegration
 //https://github.com/Kotlin/kotlin-jupyter/blob/master/libraries/krangl.json
 
 var DISPLAY_MAX_ROWS = 10
+var DISPLAY_MAX_CHARS = 50
 
 @JupyterLibrary
 internal class Integration : JupyterIntegration() {
@@ -24,7 +25,7 @@ internal class Integration : JupyterIntegration() {
         render<DataFrameSchema> { HTML(it.toHTML()) }
     }
 
-    fun DataFrame.toHTML(title: String="A DataFrame", maxRows: Int = DISPLAY_MAX_ROWS, truncate: Int = 50): String = with(StringBuilder()) {
+    fun DataFrame.toHTML(title: String="A DataFrame", maxRows: Int = DISPLAY_MAX_ROWS, truncate: Int = DISPLAY_MAX_CHARS): String = with(StringBuilder()) {
         append("<html><body>")
 
 

--- a/src/main/kotlin/krangl/integration/Integration.kt
+++ b/src/main/kotlin/krangl/integration/Integration.kt
@@ -12,6 +12,9 @@ import org.jetbrains.kotlinx.jupyter.api.libraries.JupyterIntegration
 // * https://github.com/Kotlin/kotlin-jupyter/blob/master/docs/libraries.md
 // * https://blog.jetbrains.com/kotlin/2021/04/kotlin-kernel-for-jupyter-notebook-v0-9-0/
 //https://github.com/Kotlin/kotlin-jupyter/blob/master/libraries/krangl.json
+
+var DISPLAY_MAX_ROWS = 10
+
 @JupyterLibrary
 internal class Integration : JupyterIntegration() {
     override fun Builder.onLoaded() {
@@ -21,7 +24,7 @@ internal class Integration : JupyterIntegration() {
         render<DataFrameSchema> { HTML(it.toHTML()) }
     }
 
-    fun DataFrame.toHTML(title: String="A DataFrame", maxRows: Int = 6, truncate: Int = 50): String = with(StringBuilder()) {
+    fun DataFrame.toHTML(title: String="A DataFrame", maxRows: Int = DISPLAY_MAX_ROWS, truncate: Int = 50): String = with(StringBuilder()) {
         append("<html><body>")
 
 


### PR DESCRIPTION
Added the versatility to allow a different number of records to be displayed in Jupyter Notebooks
(Previously locked at 6)

I'm unable to test it here but I did a POC in Jupyter Notebooks with the following code

(toHTML() was copied)
```kotlin
fun DataFrame.toHTML(title: String="A DataFrame", maxRows: Int = 10, truncate: Int = 50): String = with(StringBuilder()) {
        append("<html><body>")



        append("<table><tr>")

        cols.forEach { append("""<th style="text-align:left">${it.name}</th>""") }
        append("</tr>")

        rows.take(maxRows).forEach {
            append("<tr>")
            it.values.map { it.toString() }.forEach {
                val truncated = if (truncate > 0 && it.length > truncate) {
                    if (truncate < 4) it.substring(0, truncate)
                    else it.substring(0, truncate - 3) + "..."
                } else {
                    it
                }
                append("""<td style="text-align:left" title="$it">$truncated</td>""")
            }
            append("</tr>")
        }

        append("</table>")

        // render footer
        append("<p>")
        if (maxRows < rows.count()){
            append("... with ${nrow - maxRows} more rows. ")
        }

        appendLine("Shape: ${nrow} x ${ncol}. ")

/*        if (this@toHTML is GroupedDataFrame) {
            appendLine("Grouped by ${by.joinToString()} [${groups.size}]")
        } */
        append("</p>")


        append("</body></html>")
    }.toString()

fun DataFrame.display(maxRows: Int = 10, allRecords: Boolean = false): MimeTypedResult{
    val nrRecords = if(allRecords) this.nrow else maxRows
    return HTML(this.toHTML(maxRows = nrRecords))
}
```

And then calling df.display() and play around with it.

What I see as a possible point of failure is the variable visibility, I put *DISPLAY_MAX_ROWS* outside the class hoping it would be accessible as the *PRINT_MAX_ROWS* variable. Let me know if you think it makes sense.

**Reasoning:** I use krangl for work on an almost daily basis, and was previously locked to 20 rows only, the recent change made it 6 rows. Sometimes being able to see the whole DF is very helpful to retrieve a whole list of something or performing some eye checks.

Took me a few hours to understand how Jupyter worked so I could come up with the workaround I mentioned.

Thanks