### PR TITLE
Excel fixes

### DIFF
--- a/src/main/kotlin/krangl/ExcelIO.kt
+++ b/src/main/kotlin/krangl/ExcelIO.kt
@@ -287,23 +287,33 @@ private fun DataFrame.createExcelDataRows(sheet: Sheet, headers: Boolean) {
 
             when (cols[columnIndex]) {
                 is BooleanCol -> {
-                    cell.cellType = CellType.BOOLEAN
-                    cellValue?.let { cell.setCellValue(it as Boolean) }
+                    cellValue?.let {
+                        cell.cellType = CellType.BOOLEAN
+                        cell.setCellValue(it as Boolean)
+                    }
                 }
                 is DoubleCol -> {
-                    cell.cellType = CellType.NUMERIC
-                    cellValue?.let { cell.setCellValue(it as Double) }
+                    cellValue?.let {
+                        cell.cellType = CellType.NUMERIC
+                        cell.setCellValue(it as Double)
+                    }
                 }
                 is IntCol -> {
-                    cell.cellType = CellType.NUMERIC
-                    cellValue?.let { cell.setCellValue((it as Int).toDouble()) }
+                    cellValue?.let {
+                        cell.cellType = CellType.NUMERIC
+                        cell.setCellValue((it as Int).toDouble())
+                    }
                 }
-//                is StringCol -> cell.cellType= CellType.STRING
+                is LongCol -> {
+                    cellValue?.let {
+                        cell.setCellValue((it as Long).toDouble())
+                        cell.cellType = CellType.NUMERIC
+                    }
+                }
                 else -> {
                     cellValue?.let { cell.setCellValue(cellValue.toString()) }
                 }
             }
-//            cell.setCellValue(cell.toString())
         }
     }
 }

--- a/src/main/kotlin/krangl/TableIO.kt
+++ b/src/main/kotlin/krangl/TableIO.kt
@@ -445,7 +445,7 @@ internal fun peekCol(colIndex: Int, records: List<CSVRecord>, peekSize: Int = 10
 
 internal fun peekCol(records: Array<*>, peekSize: Int = 100) = records
     .asSequence()
-    .map { it.toString() }
+    .map { it?.toString() }
     .filterNotNull()
     .take(peekSize)
     .toList()

--- a/src/test/kotlin/krangl/test/ExcelTests.kt
+++ b/src/test/kotlin/krangl/test/ExcelTests.kt
@@ -133,14 +133,14 @@ class ExcelTests {
     }
 
     @Test
-    fun `readExcel -  should read bigint value`() {
+    fun `readExcel - should read bigint value`() {
 
         val df = DataFrame.readExcel(
             "src/test/resources/krangl/data/ExcelReadExample.xlsx",
             "FirstSheet"
         )
 
-        df["Activities"][1] shouldBe "432178937489174"
+        df["Activities"][1] shouldBe 432178937489174
     }
 
     @Test

--- a/src/test/kotlin/krangl/test/ExcelTests.kt
+++ b/src/test/kotlin/krangl/test/ExcelTests.kt
@@ -2,9 +2,13 @@ package krangl.test
 
 import io.kotest.matchers.shouldBe
 import krangl.*
+import org.apache.poi.ss.usermodel.CellType
 import org.apache.poi.ss.util.CellRangeAddress
 import org.apache.poi.util.LocaleUtil
+import org.apache.poi.xssf.streaming.SXSSFWorkbook
+import org.apache.poi.xssf.usermodel.XSSFWorkbook
 import org.junit.Test
+import java.io.FileInputStream
 import java.util.*
 
 
@@ -178,6 +182,13 @@ class ExcelTests {
         )
 
         writtenDF shouldBe df
+
+        val writtenBook = XSSFWorkbook(FileInputStream("src/test/resources/krangl/data/ExcelWriteResult.xlsx"))
+        val longValueCell = writtenBook.getSheet("FirstSheet").getRow(2).getCell(4)
+        longValueCell.cellType.shouldBe(CellType.NUMERIC)
+        longValueCell.numericCellValue.shouldBe(432178937489174.0)
+        val emptyValueCell = writtenBook.getSheet("FirstSheet").getRow(6).getCell(4)
+        emptyValueCell.cellType.shouldBe(CellType.BLANK)
     }
 
     @Test


### PR DESCRIPTION
Now numeric nulls are saved to Excel as blank values but not as zeroes.
(This was not catched by `writtenDF shouldBe df` because blank cells were converted to strings on reading — also fixed)